### PR TITLE
add setting modal

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/main.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/main.tsx
@@ -19,6 +19,7 @@ import { EditorBar } from './editor-bar';
 import { LeftPanel } from './left-panel';
 import { RightPanel } from './right-panel';
 import { TopBar } from './top-bar';
+import { Modals } from '@/components/ui/modal';
 
 export const Main = observer(({ projectId }: { projectId: string }) => {
     const editorEngine = useEditorEngine();
@@ -141,6 +142,7 @@ export const Main = observer(({ projectId }: { projectId: string }) => {
         <TooltipProvider>
             <div className="h-screen w-screen flex flex-row select-none relative">
                 <Canvas />
+                <Modals />
 
                 <div className="absolute top-0 w-full">
                     <TopBar />

--- a/apps/web/client/src/components/store/project/manager.ts
+++ b/apps/web/client/src/components/store/project/manager.ts
@@ -1,13 +1,30 @@
+import { extractMetadata } from './metadata';
 import type { Project } from '@onlook/models';
 import { makeAutoObservable } from 'mobx';
-
+import { normalizePath } from '../editor/sandbox/helpers';
+import type { HostingManager } from './domains/hosting';
 // Stubs for now
 export class DomainsManager {
+    private _baseHosting: HostingManager | null = null;
+    private _customHosting: HostingManager | null = null;
+
     constructor() {}
+
+    get base() {
+        return this._baseHosting;
+    }
+
+    get custom() {
+        return this._customHosting;
+    }
 }
 
 export class VersionsManager {
     constructor(private projectManager: ProjectManager) {}
+
+    get commits() {
+        return [];
+    }
 }
 
 export class ProjectManager {
@@ -39,6 +56,23 @@ export class ProjectManager {
 
     updateProject(newProject: Project) {
         this.project = newProject;
+    }
+
+    async scanProjectMetadata() {
+        try {
+            const project = this.project;
+            if (!project) {
+                return;
+            }
+            const layoutPath = normalizePath('app/layout.tsx');
+            const extractedMetadata = await extractMetadata(layoutPath);
+
+            if (extractedMetadata) {
+                this.updatePartialProject({ siteMetadata: extractedMetadata });
+            }
+        } catch (error) {
+            console.error('Error scanning project metadata:', error);
+        }
     }
 
     dispose() {}

--- a/apps/web/client/src/components/store/project/metadata.ts
+++ b/apps/web/client/src/components/store/project/metadata.ts
@@ -1,0 +1,89 @@
+import { parse, traverse } from '@onlook/parser';
+import * as t from '@babel/types';
+import type { PageMetadata } from '@onlook/models';
+import { useEditorEngine } from '@/components/store/editor';
+
+export function extractObjectValue(obj: t.ObjectExpression): Record<string, any> {
+    const result: Record<string, any> = {};
+    for (const prop of obj.properties) {
+        if (t.isObjectProperty(prop) && t.isIdentifier(prop.key)) {
+            const key = prop.key.name;
+            if (t.isStringLiteral(prop.value)) {
+                result[key] = prop.value.value;
+            } else if (t.isObjectExpression(prop.value)) {
+                result[key] = extractObjectValue(prop.value);
+            } else if (t.isArrayExpression(prop.value)) {
+                result[key] = extractArrayValue(prop.value);
+            }
+        }
+    }
+    return result;
+}
+
+export function extractArrayValue(arr: t.ArrayExpression): any[] {
+    return arr.elements
+        .map((element) => {
+            if (t.isStringLiteral(element)) {
+                return element.value;
+            } else if (t.isObjectExpression(element)) {
+                return extractObjectValue(element);
+            } else if (t.isArrayExpression(element)) {
+                return extractArrayValue(element);
+            }
+            return null;
+        })
+        .filter(Boolean);
+}
+
+export async function extractMetadata(filePath: string): Promise<PageMetadata | undefined> {
+    try {
+        const editorEngine = useEditorEngine();
+        const content = await editorEngine.sandbox.readFile(filePath);
+        if (!content) {
+            return undefined;
+        }
+
+        // Parse the file content using Babel
+        const ast = parse(content, {
+            sourceType: 'module',
+            plugins: ['typescript', 'jsx'],
+        });
+
+        let metadata: PageMetadata | undefined;
+
+        // Traverse the AST to find metadata export
+        traverse(ast, {
+            ExportNamedDeclaration(path) {
+                const declaration = path.node.declaration;
+                if (t.isVariableDeclaration(declaration)) {
+                    const declarator = declaration.declarations[0];
+                    if (
+                        t.isIdentifier(declarator?.id) &&
+                        declarator?.id?.name === 'metadata' &&
+                        t.isObjectExpression(declarator?.init)
+                    ) {
+                        metadata = {};
+                        // Extract properties from the object expression
+                        for (const prop of declarator?.init?.properties ?? []) {
+                            if (t.isObjectProperty(prop) && t.isIdentifier(prop.key)) {
+                                const key = prop.key.name;
+                                if (t.isStringLiteral(prop.value)) {
+                                    (metadata as any)[key] = prop.value.value;
+                                } else if (t.isObjectExpression(prop.value)) {
+                                    (metadata as any)[key] = extractObjectValue(prop.value);
+                                } else if (t.isArrayExpression(prop.value)) {
+                                    (metadata as any)[key] = extractArrayValue(prop.value);
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        });
+
+        return metadata;
+    } catch (error) {
+        console.error(`Error reading metadata from ${filePath}:`, error);
+        return undefined;
+    }
+} 

--- a/apps/web/client/src/components/ui/modal/index.tsx
+++ b/apps/web/client/src/components/ui/modal/index.tsx
@@ -1,15 +1,14 @@
 'use client';
 
-import { TooltipProvider } from '@onlook/ui/tooltip';
 import { SettingsModal } from './settings';
 import { SubscriptionModal } from './subscription/pricing-page';
 
 export const Modals = () => {
     return (
-        <TooltipProvider>
+        <>
             <SettingsModal />
             {/* <QuittingModal /> */}
             <SubscriptionModal />
-        </TooltipProvider>
+        </>
     );
 };

--- a/apps/web/client/src/components/ui/modal/settings/domain/base.tsx
+++ b/apps/web/client/src/components/ui/modal/settings/domain/base.tsx
@@ -1,6 +1,5 @@
 import { useProjectManager } from '@/components/store/project';
 import { HOSTING_DOMAIN } from '@onlook/constants';
-// import { invokeMainChannel } from '@/lib/utils';
 
 import { Button } from '@onlook/ui/button';
 import { Icons } from '@onlook/ui/icons';
@@ -27,7 +26,7 @@ export const BaseDomain = observer(() => {
         }
 
         const url = getValidUrl(baseUrl);
-        // invokeMainChannel(MainChannels.OPEN_EXTERNAL_WINDOW, url);
+        window.open(url, '_blank');
     };
 
     return (

--- a/apps/web/client/src/components/ui/modal/settings/domain/danger-zone.tsx
+++ b/apps/web/client/src/components/ui/modal/settings/domain/danger-zone.tsx
@@ -1,5 +1,5 @@
 import { useProjectManager } from '@/components/store/project';
-import type { DomainType } from '@onlook/models';
+import { DomainType } from '@onlook/models';
 import { PublishStatus } from '@onlook/models/hosting';
 
 import { Button } from '@onlook/ui/button';

--- a/apps/web/client/src/components/ui/modal/settings/index.tsx
+++ b/apps/web/client/src/components/ui/modal/settings/index.tsx
@@ -10,7 +10,7 @@ import { cn } from '@onlook/ui/utils';
 import { capitalizeFirstLetter } from '@onlook/utility';
 import { AnimatePresence, motion } from 'framer-motion';
 import { observer } from 'mobx-react-lite';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import AdvancedTab from './advance';
 import { DomainTab } from './domain';
 import { PreferencesTab } from './preferences';
@@ -31,13 +31,13 @@ export const SettingsModal = observer(() => {
     const project = projectsManager.project;
     const pagesManager = editorEngine.pages;
 
-    // useEffect(() => {
-    //     if (editorEngine.state.settingsOpen && project) {
-    //         pagesManager.scanPages();
-    //         editorEngine.image.scanImages();
-    //         projectsManager.scanProjectMetadata(project);
-    //     }
-    // }, [editorEngine.state.settingsOpen]);
+    useEffect(() => {
+        if (editorEngine.state.settingsOpen && project) {
+            pagesManager.scanPages();
+            editorEngine.image.scanImages();
+            projectsManager.scanProjectMetadata();
+        }
+    }, [editorEngine.state.settingsOpen]);
 
     const flattenPages = useMemo(() => {
         return pagesManager.tree.reduce((acc, page) => {
@@ -64,16 +64,16 @@ export const SettingsModal = observer(() => {
             icon: <Icons.Globe className="mr-2 h-4 w-4" />,
             component: <DomainTab />,
         },
-        {
-            label: SettingsTabValue.PROJECT,
-            icon: <Icons.Gear className="mr-2 h-4 w-4" />,
-            component: <ProjectTab />,
-        },
-        {
-            label: SettingsTabValue.VERSIONS,
-            icon: <Icons.Code className="mr-2 h-4 w-4" />,
-            component: <VersionsTab />,
-        },
+        // {
+        //     label: SettingsTabValue.PROJECT,
+        //     icon: <Icons.Gear className="mr-2 h-4 w-4" />,
+        //     component: <ProjectTab />,
+        // },
+        // {
+        //     label: SettingsTabValue.VERSIONS,
+        //     icon: <Icons.Code className="mr-2 h-4 w-4" />,
+        //     component: <VersionsTab />,
+        // },
     ];
 
     const globalTabs: SettingTab[] = [
@@ -82,11 +82,11 @@ export const SettingsModal = observer(() => {
             icon: <Icons.Person className="mr-2 h-4 w-4" />,
             component: <PreferencesTab />,
         },
-        {
-            label: SettingsTabValue.ADVANCED,
-            icon: <Icons.MixerVertical className="mr-2 h-4 w-4" />,
-            component: <AdvancedTab />,
-        },
+        // {
+        //     label: SettingsTabValue.ADVANCED,
+        //     icon: <Icons.MixerVertical className="mr-2 h-4 w-4" />,
+        //     component: <AdvancedTab />,
+        // },
     ];
 
     const pagesTabs: SettingTab[] = flattenPages.map((page) => ({
@@ -95,8 +95,7 @@ export const SettingsModal = observer(() => {
         component: <PageTab metadata={page.metadata} path={page.path} />,
     }));
 
-    const tabs = project ? [...projectOnlyTabs, ...globalTabs, ...pagesTabs] : [...globalTabs];
-
+    const tabs = project ? [...projectOnlyTabs, ...globalTabs, ...pagesTabs] : [...globalTabs];    
     return (
         <AnimatePresence>
             {editorEngine.state.settingsOpen && (
@@ -162,7 +161,7 @@ export const SettingsModal = observer(() => {
                                             ))}
                                         </div>
                                         <Separator />
-                                        <div className="shrink-0 w-48 space-y-2 p-6 text-regularPlus">
+                                        {/* <div className="shrink-0 w-48 space-y-2 p-6 text-regularPlus">
                                             <p className="text-muted-foreground text-smallPlus">
                                                 Page Settings
                                             </p>
@@ -199,7 +198,7 @@ export const SettingsModal = observer(() => {
                                                 </Button>
                                             ))}
                                         </div>
-                                        <Separator />
+                                        <Separator /> */}
                                         <div className="shrink-0 w-48 space-y-2 p-6 text-regularPlus">
                                             <p className="text-muted-foreground text-smallPlus">
                                                 Global Settings

--- a/apps/web/client/src/components/ui/modal/settings/preferences.tsx
+++ b/apps/web/client/src/components/ui/modal/settings/preferences.tsx
@@ -30,10 +30,10 @@ export const PreferencesTab = observer(() => {
         await userManager.settings.updateEditor({ ideType: ide.type });
     }
 
-    async function updateAnalytics(enabled: boolean) {
-        await userManager.settings.update({ enableAnalytics: enabled });
-        invokeMainChannel(MainChannels.UPDATE_ANALYTICS_PREFERENCE, enabled);
-    }
+    // async function updateAnalytics(enabled: boolean) {
+    //     await userManager.settings.update({ enableAnalytics: enabled });
+    //     invokeMainChannel(MainChannels.UPDATE_ANALYTICS_PREFERENCE, enabled);
+    // }
 
     async function updateDeleteWarning(enabled: boolean) {
         await userManager.settings.updateEditor({ shouldWarnDelete: enabled });
@@ -173,7 +173,7 @@ export const PreferencesTab = observer(() => {
                     </DropdownMenuContent>
                 </DropdownMenu>
             </div>
-            <div className="flex justify-between items-center gap-4">
+            {/* <div className="flex justify-between items-center gap-4">
                 <div className="flex flex-col gap-2">
                     <p className="text-largePlus">Analytics</p>
                     <p className="text-foreground-onlook text-small">
@@ -197,7 +197,7 @@ export const PreferencesTab = observer(() => {
                         </DropdownMenuItem>
                     </DropdownMenuContent>
                 </DropdownMenu>
-            </div>
+            </div> */}
         </div>
     );
 });

--- a/apps/web/client/src/components/ui/modal/settings/site/index.tsx
+++ b/apps/web/client/src/components/ui/modal/settings/site/index.tsx
@@ -6,12 +6,13 @@ import { observer } from 'mobx-react-lite';
 import { useState } from 'react';
 import { MetadataForm } from './metadata-form';
 import { useMetadataForm } from './use-metadata-form';
+import { DefaultSettings } from '@onlook/constants';
 
 export const SiteTab = observer(() => {
     const editorEngine = useEditorEngine();
     const projectsManager = useProjectManager();
     const project = projectsManager.project;
-    const siteSetting = project?.metadata;
+    const siteSetting = project?.siteMetadata;
     const baseUrl = project?.domains?.custom?.url ?? project?.domains?.base?.url ?? project?.url;
 
     const {
@@ -83,7 +84,7 @@ export const SiteTab = observer(() => {
 
             projectsManager.updatePartialProject({
                 ...project,
-                metadata: updatedMetadata,
+                siteMetadata: updatedMetadata,
             });
 
             await editorEngine.pages.updateMetadataPage('/', updatedMetadata);

--- a/apps/web/client/src/components/ui/modal/settings/site/use-metadata-form.ts
+++ b/apps/web/client/src/components/ui/modal/settings/site/use-metadata-form.ts
@@ -1,6 +1,5 @@
 import type { PageMetadata } from '@onlook/models';
 import { useEffect, useState } from 'react';
-
 interface UseMetadataFormProps {
     initialMetadata?: PageMetadata;
     defaultTitle?: string;

--- a/packages/models/src/project/project.ts
+++ b/packages/models/src/project/project.ts
@@ -1,6 +1,10 @@
+import type { DomainSettings } from 'src/project/domain';
+import type { PageMetadata } from 'src/pages';
+
 export interface Project {
     id: string;
     name: string;
+    url: string;
     metadata: {
         createdAt: string;
         updatedAt: string;
@@ -11,4 +15,10 @@ export interface Project {
         id: string;
         url: string;
     };
+    siteMetadata: PageMetadata;
+    domains: {
+        base: DomainSettings | null;
+        custom: DomainSettings | null;
+    } | null;
+    env?: Record<string, string>;
 }


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


---

This pull request introduces a settings modal to the `kodustech/onlook` repository, merging changes from the `feat/add-setting-modal` branch into the `main` branch. Key updates include:

1. **Modals Integration**: The `Modals` component is imported and rendered within the `Main` component's layout to provide modal functionality for the project view.

2. **Project Management Enhancements**: New manager classes (`DomainsManager`, `VersionsManager`) are added with initial structures and getters. The `ProjectManager` now includes functionality to scan and parse project metadata from a specified layout file, updating the project state with limited error handling.

3. **Metadata Handling**: Functionality to extract metadata from files by parsing their AST is introduced. Suggestions for code refactoring, type safety improvements, and documentation enhancements are provided.

4. **UI Component Refactoring**: The `Modals` component is refactored by replacing the `TooltipProvider` with a React Fragment, simplifying the structure. The mechanism for opening external URLs is updated to use `window.open(url, '_blank')`.

5. **Settings Modal Adjustments**: The settings modal sees several updates, including re-enabling a `useEffect` hook for data scanning, commenting out analytics-related functionality, and renaming a property from `metadata` to `siteMetadata` for site-specific settings.

6. **Project Interface Updates**: The `Project` interface is enhanced with new fields for `url`, `siteMetadata`, `domains`, and an optional `env` for environment variables, along with necessary type imports.

These changes collectively aim to enhance the functionality and maintainability of the project settings and metadata management within the application.